### PR TITLE
[FEAT] 설문조사 조회 및 삭제

### DIFF
--- a/src/main/java/com/sc/surveymarket/controller/SurveyController.java
+++ b/src/main/java/com/sc/surveymarket/controller/SurveyController.java
@@ -18,13 +18,30 @@ public class SurveyController {
 
     @PostMapping
     public ResponseEntity register(@Valid @RequestBody SurveyRegisterReqDto surveyRegisterReqDto) {
-
         SurveyResDto surveyResDto = surveyService.register(surveyRegisterReqDto);
-
         return ResponseEntity.ok(ResponseDto.builder()
                 .code(1)
                 .message("Success")
                 .data(surveyResDto)
+                .build());
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity retrieve(@PathVariable String id) {
+        SurveyResDto surveyResDto = surveyService.retrieve(id);
+        return ResponseEntity.ok(ResponseDto.builder()
+                .code(1)
+                .message("Success")
+                .data(surveyResDto)
+                .build());
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity delete(@PathVariable String id) {
+        surveyService.delete(id);
+        return ResponseEntity.ok(ResponseDto.builder()
+                .code(1)
+                .message("Success")
                 .build());
     }
 

--- a/src/main/java/com/sc/surveymarket/dto/survey/SurveyResDto.java
+++ b/src/main/java/com/sc/surveymarket/dto/survey/SurveyResDto.java
@@ -31,6 +31,7 @@ public class SurveyResDto {
         return SurveyResDto.builder()
                 .id(survey.getId())
                 .title(survey.getTitle())
+                .questionList(survey.getQuestionList())
                 .build();
     }
 }

--- a/src/main/java/com/sc/surveymarket/exception/CustomAPIException.java
+++ b/src/main/java/com/sc/surveymarket/exception/CustomAPIException.java
@@ -1,0 +1,7 @@
+package com.sc.surveymarket.exception;
+
+public class CustomAPIException extends RuntimeException {
+    public CustomAPIException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/sc/surveymarket/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/sc/surveymarket/exception/CustomExceptionHandler.java
@@ -1,0 +1,65 @@
+package com.sc.surveymarket.exception;
+
+import com.sc.surveymarket.dto.ResponseDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RestControllerAdvice
+public class CustomExceptionHandler {
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity exception(Exception e) {
+        log.error(e.getMessage());
+        return ResponseEntity
+                .badRequest()
+                .body(ResponseDto.builder()
+                        .code(-1)
+                        .message("서버에서 오류가 발생하였습니다.")
+                        .build());
+    }
+
+    @ExceptionHandler(CustomAPIException.class)
+    public ResponseEntity customAPIException(CustomAPIException e) {
+        log.error(e.getMessage());
+        return ResponseEntity
+                .badRequest()
+                .body(ResponseDto.builder()
+                        .code(-1)
+                        .message(e.getMessage())
+                        .build());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity methodArgumentNotValidException(MethodArgumentNotValidException e) {
+        log.error(e.getMessage());
+
+        BindingResult bindingResult = e.getBindingResult();
+        Map<String, String> errorMap = new HashMap<>();
+
+        if (bindingResult.hasErrors()) {
+            errorMap = bindingResult.getFieldErrors()
+                    .stream()
+                    .collect(Collectors.toMap(FieldError::getField, FieldError::getDefaultMessage));
+        }
+
+        return ResponseEntity
+                .badRequest()
+                .body(ResponseDto.builder()
+                        .code(-1)
+                        .message("데이터 유효성 검증에 실패하였습니다.")
+                        .data(errorMap)
+                        .build());
+    }
+}

--- a/src/main/java/com/sc/surveymarket/service/SurveyService.java
+++ b/src/main/java/com/sc/surveymarket/service/SurveyService.java
@@ -3,6 +3,7 @@ package com.sc.surveymarket.service;
 import com.sc.surveymarket.document.Survey;
 import com.sc.surveymarket.dto.survey.SurveyRegisterReqDto;
 import com.sc.surveymarket.dto.survey.SurveyResDto;
+import com.sc.surveymarket.exception.CustomAPIException;
 import com.sc.surveymarket.repository.SurveyRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -10,19 +11,24 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class SurveyService {
-
     private final SurveyRepository surveyRepository;
 
     public SurveyResDto register(SurveyRegisterReqDto surveyRegisterReqDto) {
-
         Survey survey = Survey.builder()
                 .title(surveyRegisterReqDto.getTitle())
                 .questionList(surveyRegisterReqDto.getQuestionList())
                 .build();
-
         Survey savedSurvey = surveyRepository.save(survey);
-
         return SurveyResDto.create(savedSurvey);
     }
 
+    public SurveyResDto retrieve(String id) {
+        Survey findSurvey = surveyRepository.findById(id)
+                .orElseThrow(() -> new CustomAPIException("{}에 해당하는 Survey가 존재하지 않습니다."));
+        return SurveyResDto.create(findSurvey);
+    }
+
+    public void delete(String id) {
+        surveyRepository.deleteById(id);
+    }
 }


### PR DESCRIPTION
# ✏️ Description
등록한 설문조사를 조회 및 삭제하는 로직을 구현한다.
사용자로부터 설문조사(`survey`)의 `id` 값을 전달받으면 해당 `id` 값에 해당하는 설문조사가 존재한다면 해당 설문조사의 값을 조회 및 삭제한다.

# 🔥 조회 및 삭제

### 💻 Controller
```java
@GetMapping("/{id}")
public ResponseEntity retrieve(@PathVariable String id) {
    SurveyResDto surveyResDto = surveyService.retrieve(id);
    return ResponseEntity.ok(ResponseDto.builder()
            .code(1)
            .message("Success")
            .data(surveyResDto)
            .build());
}

@DeleteMapping("/{id}")
public ResponseEntity delete(@PathVariable String id) {
    surveyService.delete(id);
    return ResponseEntity.ok(ResponseDto.builder()
            .code(1)
            .message("Success")
            .build());
}
```
사용자로부터 id를 전달받아 해당 survey를 조회 및 삭제한다.

# 🔥 예외처리

### 💻  @RestControllerAdvice
```java
@Slf4j
@RestControllerAdvice
public class CustomExceptionHandler {

    @ExceptionHandler(Exception.class)
    public ResponseEntity exception(Exception e) {
        log.error(e.getMessage());
        return ResponseEntity
                .badRequest()
                .body(ResponseDto.builder()
                        .code(-1)
                        .message("서버에서 오류가 발생하였습니다.")
                        .build());
    }

    @ExceptionHandler(CustomAPIException.class)
    public ResponseEntity customAPIException(CustomAPIException e) {
        log.error(e.getMessage());
        return ResponseEntity
                .badRequest()
                .body(ResponseDto.builder()
                        .code(-1)
                        .message(e.getMessage())
                        .build());
    }

    @ExceptionHandler(MethodArgumentNotValidException.class)
    public ResponseEntity methodArgumentNotValidException(MethodArgumentNotValidException e) {
        log.error(e.getMessage());

        BindingResult bindingResult = e.getBindingResult();
        Map<String, String> errorMap = new HashMap<>();

        if (bindingResult.hasErrors()) {
            errorMap = bindingResult.getFieldErrors()
                    .stream()
                    .collect(Collectors.toMap(FieldError::getField, FieldError::getDefaultMessage));
        }

        return ResponseEntity
                .badRequest()
                .body(ResponseDto.builder()
                        .code(-1)
                        .message("데이터 유효성 검증에 실패하였습니다.")
                        .data(errorMap)
                        .build());
    }
}
```
예외가 발생할 경우를 처리하기 위한 `Exception.class`, 특정 상황에 맞는 `message`를 반환하기 위한 `CustomAPIException.class`, 
`@Valid` 입력 값에 대한 예외처리를 하기 위한 `MethodArgumentNotValidException.class` 을 `@ExceptionHandler`에 등록한다.